### PR TITLE
Provide more suitable "read more" URL on feature flags

### DIFF
--- a/.changeset/proud-cherries-impress.md
+++ b/.changeset/proud-cherries-impress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+Changed the 'Read more' button URL regarding feature flags.

--- a/plugins/user-settings/src/components/FeatureFlags/EmptyFlags.tsx
+++ b/plugins/user-settings/src/components/FeatureFlags/EmptyFlags.tsx
@@ -46,7 +46,7 @@ export const EmptyFlags = () => (
         <Button
           variant="contained"
           color="primary"
-          href="https://backstage.io/docs/api/utility-apis"
+          href="https://backstage.io/docs/plugins/feature-flags/"
         >
           Read More
         </Button>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The **Settings** > **Feature flags** page has an empty state showing a **READ MORE** button.

![image](https://github.com/giantswarm/backstage-fork/assets/273727/f5b1594a-cdae-48bd-a626-8513d77a5721)

This button currently takes users to the [Utility APIs](https://backstage.io/docs/api/utility-apis) docs page. However, that pae does not mention feature flags.

I'm proposing to let the link point to the [Feature Flags](https://backstage.io/docs/plugins/feature-flags/) page instead.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
